### PR TITLE
Update action-mattermost-notify.yaml

### DIFF
--- a/.github/workflows/action-mattermost-notify.yaml
+++ b/.github/workflows/action-mattermost-notify.yaml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
 
-  pull_request:
+  pull_request_target:
     types: [opened, edited, closed, reopened]
 
   issues:


### PR DESCRIPTION
pull_request_target is to be used for the notifications
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target